### PR TITLE
Set automatic draw order to avoid transparent objects occluding others

### DIFF
--- a/js/m.viewer.js
+++ b/js/m.viewer.js
@@ -125,10 +125,6 @@ jQuery(document).ready(function() {
 // load the landmarks
   preloadLandmark();
 
-// stackoverflow.com/question/17462936/xtk-flickering-in-overlay-mesh
-// resolve multiple mesh transparent object being rendered causing flickering
-// effect
-  ren3d.config.ORDERING_ENABLED=false;
   show_caption=false;
 
 // zoom in alittle


### PR DESCRIPTION
The 'ORDERING_ENABLED' had been set to false. Normally, this will auto-order
objects from back-to-front to ensure objects are drawn correctly during render
times. Setting this to false appears to render them in the order they are listed
in the object file, which can allow the user to view them from the 'wrong' angle,
causing the 'wrong' draw order and some objects to simply not show up.

The config option was set in the initial commit of this git project, and no changes
appear to have been made to the X Toolkit since then. That makes me think the flickering problems the original author mentioned were bad enough to turn this setting off, and I don't see any evidence the old flickering problems would have been fixed in the X Toolkit. 

I only rarely see popping or flickering with this setting enabled. I've only noticed this when two objects intersect and the ordering algorithm is having trouble deciding which object is on top, similar to
the Z-Fighting problem. 

I didn't find any documentation on the ORDERING_ENABLED config option, but I did find
the only commit in the X toolkit mentioning it:

https://github.com/xtk/X/commit/ad2eeb071c7ec64d0a71dc9715ef8844b616fdbd