### PR TITLE
Support leaving the link field undefined.

### DIFF
--- a/js/m.viewer.js
+++ b/js/m.viewer.js
@@ -1074,15 +1074,19 @@ function getHref(t) {
   return(null);
 }
 
+// Get the Label for a mesh
+// Try these locations in order until one works:
+//  * mesh.link.label
+//  * mesh.label
+//  * basename(mesh.url)
 function getLabel(t) {
-  var _label = t['link']['label'];
-  if(_label == undefined) {
-    _label = t['label'];
+  if (t['link'] != undefined && t['link']['label'] != undefined) {
+    return t['link']['label'];
   }
-  if (_label == undefined) {
-    _label = chopForStub(t['url']);
+  if (t['label'] != undefined) {
+    return t['label'];
   }
-  return _label;
+  return chopForStub(t['url']);
 }
 
 //


### PR DESCRIPTION
Support a mesh with the following JSON, which leaves the "link" field absent: 

        "mesh": [
            {
                "id": "60195",
                "url": "http://example.com/foo.obj.gz",
                "color": [
                    1,
                    0,
                    1
                ],
                "label": "foo-label",
                "opacity": 1,
                "description": null
            },
        ]

This will fix the example model here: https://dev.facebase.org/mesh-viewer/view.html?model=/ermrest/catalog/1/entity/viz:model_json/id=1