### PR TITLE
Changes to limit distance calculations to one mesh at a time

### DIFF
--- a/js/m.sidebar-landmarks.js
+++ b/js/m.sidebar-landmarks.js
@@ -105,9 +105,16 @@ function calculateLandmarkDistances()
   toggleActiveSidebar('landmarks');
   jQuery('#landmarklist').empty();
 
-  if (countSelectedLandmarks() < 2) {
+  var meshListWithLandmarks = getMeshesWithMultipleActiveLandmarks()
+  if (meshListWithLandmarks <= 1) {
+    console.debug('No mesh with active landmarks to display, aborting distance calculation.')
     return
   }
+  //Grab first one in list
+  var mesh = meshListWithLandmarks[0]
+
+  function allOtherMeshes(meshID, landmarkID) {return mesh[1].id.toLowerCase() != meshID}
+  setLandmarksActive(false, allOtherMeshes)
 
   var lmark_list = landmarks;
   // Check if any landmarks have 'order' set on them. If any do, treat the whole set as 'ordered'.
@@ -167,19 +174,6 @@ function calculateLandmarkDistance(landmark1, landmark2)
   p1 = new X.vector(lp1[0], lp1[1], lp1[2]);
   p2 = new X.vector(lp2[0], lp2[1], lp2[2]);
   return X.vector.distance(p1, p2);
-}
-
-function countSelectedLandmarks()
-{
-  var num_selected = 0;
-  landmarks.forEach(function(landmark)
-  {
-    if (landmark[0].visible)
-    {
-      num_selected++;
-    }
-  });
-  return num_selected;
 }
 
 

--- a/js/m.viewer.js
+++ b/js/m.viewer.js
@@ -512,6 +512,7 @@ function preloadLandmarks(landmarks)
     show_landmark=true;
     $('#landmarkbtn').addClass('pick');
   }
+  updateCalculateDistanceButton()
 }
 
 // similar to selectLandmark but for view.html
@@ -527,6 +528,7 @@ function toggleAllLandmark()
       $('#landmarkbtn').removeClass('pick');
       setLandmarksActive(false)
   }
+  updateCalculateDistanceButton()
 }
 
 // Enable or disable all landmarks, set to true or false based on the 'state'
@@ -545,6 +547,11 @@ function setLandmarksActive(state, filterFunction=null) {
       landmarklist[_g][_i].visible=state;
     }
   }
+}
+
+function updateCalculateDistanceButton() {
+  const state = getMeshesWithMultipleActiveLandmarks().length == 0;
+  $('#calculatedistbtn').prop('disabled', state);
 }
 
 
@@ -650,6 +657,22 @@ function openMesh(i,label_name,opacity_name,landmark_name,opacity_btn) {
       setLandmarksActive(false, filterByMesh)
     }
   }
+  updateCalculateDistanceButton()
+}
+
+function getMeshesWithMultipleActiveLandmarks() {
+  var meshesWithVisibleLandmarks = meshs.filter(function (mesh) {
+    const meshKey = mesh[1].id.toLowerCase();
+    if (landmarklist.hasOwnProperty(meshKey) && landmarklist[meshKey].length > 1) {
+      const activeLandmarks = landmarklist[meshKey].filter(function (landmark) {
+        return landmark.visible;
+      })
+      if (activeLandmarks.length > 1) {
+        return mesh;
+      }
+    }
+  });
+  return meshesWithVisibleLandmarks;
 }
 
 function toggleOpacityIcon(btn) {
@@ -838,6 +861,7 @@ function toggleLandmark(g,i) {
          }
      }
   }
+  updateCalculateDistanceButton();
 }
 
 function toggleLabel() {


### PR DESCRIPTION
Changes for issue #39 

Distances will only be calculated for one mesh at a time. Additionally, the calculate button will be disabled/enabled to show when a valid selection has been chosen. 

@robes I found some additional things to refactor while looking into these changes, but I didn't want these changes to become too significant so I held off. I put those changes [here](https://github.com/informatics-isi-edu/mesh-viewer/commit/e40de4f9a646ed4ac79073210d9c08e8df50237b) for now, and made a note about a quirk I ran into. 