### PR TITLE
Fixed inconsistencies in README documentation, spec changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,32 +63,27 @@ Example URL with query parameters:
 
 Valid properties for model specification referenced by `model_url`:
 
-* model_id - (string) The id of the model
-* model_caption - (string) The caption of the model
+* RID - (string) The id of the model
 * bg_color_r, bg_color_g, bg_color_b (int [0-255]) - RGB values for the background
 * bounding_box_color_r, bounding_box_color_g, bounding_box_color_b (int [0-255]) -
  Color of the Bounding Box
-* model_measurement - (string [inches, cm]) units of distance measurement
-* model_unitconversion - (float [1.0]) Multiplied by world-space distance to
+* measurement - (string [inches, cm]) units of distance measurement
+* unitconversion - (float [1.0]) Multiplied by world-space distance to
  convert world-space distances to model_measurement distances
 
 Example:
 ```
 [
   {
-    "id": 54,
-    "label": "E18.5 wildtype mouse - hard tissue",
-    "description": null,
+    "RID": "1-43KT",
     "bg_color_r": 0,
     "bg_color_g": 0,
     "bg_color_b": 0,
     "bounding_box_color_r": 255,
     "bounding_box_color_g": 255,
     "bounding_box_color_b": 0,
-    "rotate": false,
-    "volume": null,
-    "RID": "1-43KT",
-    "unit_conversion": null
+    "measurement": "cm",
+    "unitconversion": 1.0
   }
 ]
 ```
@@ -99,11 +94,9 @@ Valid properties for meshes specification referenced by `mesh_url`:
 
 * RID - (string) The ID of the Mesh.
 * url - (string) The location where the object data resides for this mesh
-* link - (object) An object containing a URL and label description of the mesh
-    * Example ```{"url": "http://example.com", "label": "Mesh URL"}
-* anatomy - (string) The label for the anatomy this mesh describes
-* anatomy_id - (string) The id for the anatomy term (optional)
-* description - (string) A description of the Mesh
+* anatomy - (string) Name of the anatomy this mesh points
+* anatomy_id - (string) ID for the anatomy. Used with `anatomy_url_fragment` for constructing a link back to the anatomy.
+* label - (string) Can be used instead of `anatomy` as an alternative description.
 * opacity - (float [0-1])Opacity for this mesh
 * color_r, color_g, color_b - (int [0-255]) RGB color values for the mesh color
 
@@ -113,14 +106,13 @@ Example:
   {
     "RID": "1-444E",
     "url": "http://mysite.org/my_meshes.obj.gz",
+    "anatomy":"frontal suture",
+    "anatomy_id":"1-4FC4",
     "label": null,
-    "description": null,
     "color_r": 66,
     "color_g": 137,
     "color_b": 244,
-    "opacity": 1,
-    "anatomy": "occipital bone",
-    "anatomy_id": "1-3406"
+    "opacity": 1
   }
 ]
 ```
@@ -131,14 +123,10 @@ Valid properties for landmark specification referenced by `landmark_url`:
 
 * RID - (string) The ID of the Landmark.
 * mesh - (string) The ID of the Mesh this landmark points
+* anatomy - (string) Name of the anatomy this landmark points
+* anatomy_id - (string) ID for the anatomy. Used with `anatomy_url_fragment` for constructing a link back to the anatomy.
+* label - (string) Can be used instead of `anatomy` as an alternative description.
 * point_x, point_y, point_z - (float [-inf,inf]) The location of the landmark
-* url - (string) The location where the object data resides for this mesh
-* link - (object) An object containing a URL and label description of the mesh
-    * Example ```{"url": "http://example.com", "label": "Mesh URL"}
-* anatomy - (string) The label for the anatomy this mesh describes
-* anatomy_id - (string) The id for the anatomy term (optional)
-* description - (string) A description of the Mesh
-* opacity - (float [0-1])Opacity for this mesh
 * color_r, color_g, color_b - (int [0-255]) RGB color values for the mesh color
 * radius - (float [typically 0.1]) The radius of the spherical marker denoting the landmark.
 
@@ -147,17 +135,16 @@ Valid properties for landmark specification referenced by `landmark_url`:
   {
     "RID": "1-4452",
     "mesh": "1-43E0",
+    "anatomy": null,
+    "anatomy_id": null,
     "label": "Inferior point of mandibular body",
-    "description": null,
     "point_x": 7.8618,
     "point_y": 2.5692,
     "point_z": 1.8701,
-    "radius": 0.1,
     "color_r": 0,
     "color_g": 0,
     "color_b": 255,
-    "anatomy": "mandible",
-    "anatomy_id": "1-340A"
+    "radius": 0.1,
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Valid properties for model specification referenced by `model_url`:
 * bg_color_r, bg_color_g, bg_color_b (int [0-255]) - RGB values for the background
 * bounding_box_color_r, bounding_box_color_g, bounding_box_color_b (int [0-255]) -
  Color of the Bounding Box
-* measurement - (string [inches, cm]) units of distance measurement
-* unitconversion - (float [1.0]) Multiplied by world-space distance to
+* units - (string [units]) type of distance measurement, such as 'cm', or 'inches'.
+* unit_conversion - (float [1.0]) Multiplied by world-space distance to
  convert world-space distances to model_measurement distances
 
 Example:
@@ -82,8 +82,8 @@ Example:
     "bounding_box_color_r": 255,
     "bounding_box_color_g": 255,
     "bounding_box_color_b": 0,
-    "measurement": "cm",
-    "unitconversion": 1.0
+    "units": "units",
+    "unit_conversion": 1.0
   }
 ]
 ```
@@ -94,9 +94,9 @@ Valid properties for meshes specification referenced by `mesh_url`:
 
 * RID - (string) The ID of the Mesh.
 * url - (string) The location where the object data resides for this mesh
-* anatomy - (string) Name of the anatomy this mesh points
+* anatomy - (string) If given, the value for anatomy will be used as the display label for the mesh.
 * anatomy_id - (string) ID for the anatomy. Used with `anatomy_url_fragment` for constructing a link back to the anatomy.
-* label - (string) Can be used instead of `anatomy` as an alternative description.
+* label - (string) Can be as an alternative for the display label for the mesh, if the `anatomy` is not given.
 * opacity - (float [0-1])Opacity for this mesh
 * color_r, color_g, color_b - (int [0-255]) RGB color values for the mesh color
 
@@ -123,9 +123,9 @@ Valid properties for landmark specification referenced by `landmark_url`:
 
 * RID - (string) The ID of the Landmark.
 * mesh - (string) The ID of the Mesh this landmark points
-* anatomy - (string) Name of the anatomy this landmark points
+* anatomy - (string) If given, the value for `anatomy` will be used as the display label for the landmark.
 * anatomy_id - (string) ID for the anatomy. Used with `anatomy_url_fragment` for constructing a link back to the anatomy.
-* label - (string) Can be used instead of `anatomy` as an alternative description.
+* label - (string) Can be as an alternative for the display label for the landmark, if the `anatomy` is not given.
 * point_x, point_y, point_z - (float [-inf,inf]) The location of the landmark
 * color_r, color_g, color_b - (int [0-255]) RGB color values for the mesh color
 * radius - (float [typically 0.1]) The radius of the spherical marker denoting the landmark.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Valid properties for model specification referenced by `model_url`:
 * bg_color_r, bg_color_g, bg_color_b (int [0-255]) - RGB values for the background
 * bounding_box_color_r, bounding_box_color_g, bounding_box_color_b (int [0-255]) -
  Color of the Bounding Box
-* units - (string [units]) type of distance measurement, such as 'cm', or 'inches'.
+* units - (string Default: 'mm') type of distance measurement, such as inches. Defaults to 'mm'.
 * unit_conversion - (float [1.0]) Multiplied by world-space distance to
  convert world-space distances to model_measurement distances
 
@@ -82,7 +82,7 @@ Example:
     "bounding_box_color_r": 255,
     "bounding_box_color_g": 255,
     "bounding_box_color_b": 0,
-    "units": "units",
+    "units": "mm",
     "unit_conversion": 1.0
   }
 ]

--- a/js/m.setup.js
+++ b/js/m.setup.js
@@ -16,7 +16,7 @@ var model_caption=null;
 var model_color=[1,1,1];
 var model_bbox=[0,0,0];
 var model_clip=null;
-var model_measurement='units';
+var model_measurement='mm';
 var model_unitconversion=1.0;
 
 // Most URLs for meshes and landmarks expect to fetch resources from the server

--- a/js/m.setup.js
+++ b/js/m.setup.js
@@ -212,8 +212,8 @@ function setupModel(model) {
                             model_settings.bounding_box_color_b,
                              ) || model_bbox;
     model_clip = model_settings.clip || model_clip;
-    model_measurement = model_settings.measurement || model_measurement;
-    model_unitconversion = model_settings.unitconversion || model_unitconversion;
+    model_measurement = model_settings.units || model_measurement;
+    model_unitconversion = model_settings.unit_conversion || model_unitconversion;
     return 'Global Variables for model id "' + model_id + '" have been set.'
   }
   console.warning('Model not properly set, continuing with defaults...')

--- a/js/m.setup.js
+++ b/js/m.setup.js
@@ -30,8 +30,8 @@ if (location.hostname === "localhost" || location.hostname === "127.0.0.1")
 // All arguments here are HTTP URLs. Each GET will fetch JSON.
 const URL_ARGUMENTS = {
   'model_url': setupModel,
-  'meshes_url': setupMeshes,
-  'landmarks_url': setupLandmarks,
+  'mesh_url': setupMeshes,
+  'landmark_url': setupLandmarks,
 }
 
 // Other fragment arguments, simply passed to the function defined below
@@ -45,8 +45,8 @@ const GENERAL_ARGUMENTS = {
 // example.com/view.html#model_url=<model_url>&meshes_url=<mesh_url>
 const MESH_VIEWER_ARGUMENT_DEFAULTS = {
   'model_url': {},
-  'meshes_url': [],
-  'landmarks_url': [],
+  'mesh_url': [],
+  'landmark_url': [],
   'anatomy_url_fragment': null
 }
 
@@ -212,7 +212,7 @@ function setupModel(model) {
                             model_settings.bounding_box_color_b,
                              ) || model_bbox;
     model_clip = model_settings.clip || model_clip;
-    model_measurement = model_settings.model_measurements || model_measurement;
+    model_measurement = model_settings.measurement || model_measurement;
     model_unitconversion = model_settings.unitconversion || model_unitconversion;
     return 'Global Variables for model id "' + model_id + '" have been set.'
   }
@@ -224,9 +224,9 @@ function setupMeshes(meshes) {
   meshes.forEach(function (mesh) {
     var formattedMesh = {
       'id': mesh.RID,
-      'link': mesh.link || {'url': null, 'label': null},
-      'label': mesh.anatomy,
-      'description': mesh.description,
+      'link': {'url': null, 'label': null},
+      'label': mesh.anatomy || mesh.label,
+      'anatomy_id': mesh.anatomy_id,
       'url': development_hostname + mesh.url,
       'opacity': mesh.opacity,
       'color': parseColor(mesh.color_r, mesh.color_b, mesh.color_g)
@@ -241,13 +241,13 @@ function setupLandmarks(landmarks) {
   landmarks.forEach(function (landmark) {
     var formattedLandmark = {
       'id': landmark.RID,
+      'link': {'url': null, 'label': null},
+      'label': landmark.anatomy || landmark.label,
+      'anatomy_id': landmark.anatomy_id,
       'group': landmark.mesh,
-      'description': landmark.description,
       'point': [landmark.point_x, landmark.point_y, landmark.point_z],
-      'color': parseColor(landmark.color_r, landmark.color_b, landmark.color_g),
-      'label': landmark.label || '',
-      'link': landmark.link || {'url': null, 'label': null},
       'radius': landmark.radius || 0.1,
+      'color': parseColor(landmark.color_r, landmark.color_b, landmark.color_g),
     }
     formattedLandmarks.push(formattedLandmark);
   });
@@ -266,12 +266,14 @@ function setupLandmarks(landmarks) {
 function postSetup(model) {
   var formattedModel = {
     'model': model['model_url'],
-    'meshes': model['meshes_url'],
-    'landmarks': model['landmarks_url'],
+    'meshes': model['mesh_url'],
+    'landmarks': model['landmark_url'],
   }
   if (model.anatomy_url_fragment) {
     function setURL(meshOrLandmark) {
-      meshOrLandmark.link.url = model.anatomy_url_fragment + meshOrLandmark.id;
+      if (meshOrLandmark.anatomy_id) {
+        meshOrLandmark.link.url = model.anatomy_url_fragment + meshOrLandmark.anatomy_id;
+      }
     }
     formattedModel.meshes.forEach(setURL);
     formattedModel.landmarks.forEach(setURL);


### PR DESCRIPTION
This mainly fixes some bad documentation, and also adds a couple fixes for things correctly documented but differed in the code. 

Changes for #45. 

Notes on code changes: 
* Code previously used incorrect URL fragment `url_meshes`, and has now been changed to the correct value `url_mesh`. 
* Code previously used incorrect URL fragment `url_landmarks`, and has now been changed to the correct value `url_landmark`. 
* Code previously constructed links for landmarks/meshes using the landmark/mesh ID, rather than using the passed in `anatomy_id` value. Mesh-Viewer now uses `anatomy_id` when constructing links. 
* `anatomy` is now used for the default label, falling back on `label` if `anatomy` is not present. 