### PR TITLE
Fixed mesh viewer not producing mesh/landmark links given Label_RID

### DIFF
--- a/js/m.setup.js
+++ b/js/m.setup.js
@@ -230,6 +230,7 @@ function setupMeshes(meshes) {
       'id': mesh['RID'],
       'link': {'url': null, 'label': null},
       'label': mesh['Label'] || mesh['Label_Alt'],
+      'labelRID': mesh['Label_RID'],
       'url': development_hostname + mesh['URL'],
       'opacity': mesh['Opacity'],
       'color': parseColor(mesh.Color_R, mesh.Color_G, mesh.Color_B)
@@ -277,8 +278,8 @@ function postSetup(model) {
   }
   if (formattedModel.resolver) {
     function setURL(meshOrLandmark) {
-      if (meshOrLandmark['Label_RID']) {
-        meshOrLandmark.link.url = formattedModel.resolver + meshOrLandmark['Label_RID'];
+      if (meshOrLandmark['labelRID']) {
+        meshOrLandmark.link.url = formattedModel.resolver + meshOrLandmark['labelRID'];
       }
     }
     formattedModel.meshes.forEach(setURL);


### PR DESCRIPTION
Fixed the links not showing up for meshes or landmarks. 

mesh-viewer internally uses a random mixture of snake_case and camelCase. This fix keeps the spec using its own case style while keeping the internal ones consistent.

Generally for this project I'm trying to phase out snake_case where possible so there aren't multiple styles being used within the project.